### PR TITLE
Add MicroPython robotic arm control system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# robot-arm
+# Robot Arm
+
+This project provides MicroPython code for controlling a four-servo robotic arm with a Raspberry Pi Pico. The Pico communicates with a PCA9685 16-channel PWM driver to move the servos. A three-axis joystick with a push button directs the arm.
+
+## Hardware
+
+- Raspberry Pi Pico running MicroPython
+- PCA9685 16-channel 12-bit PWM driver
+- Four hobby servos connected to channels 0–3
+- Three-axis analog joystick with one push button
+
+## Project Structure
+
+```
+main.py              # Entry point for the Pico
+arm/
+  __init__.py
+  joystick.py        # Reads joystick axes and button
+  pca9685.py         # Minimal driver for the PCA9685
+  servo_controller.py# Helper for setting servo angles
+  robot_arm.py       # High level coordination
+tests/
+  test_angles.py     # Unit tests for angle conversions
+```
+
+## Usage
+
+1. Copy `main.py` and the `arm` package to the Pico.
+2. Connect the joystick axes to ADC pins and the button to a GPIO pin.
+3. Wire the PCA9685 to the I2C pins of the Pico and connect servos to channels 0–3.
+4. On reset the script will continually read the joystick and move the servos.
+
+## Development
+
+Run basic checks with:
+
+```
+python -m py_compile $(git ls-files '*.py')
+python -m pytest
+```
+

--- a/arm/angles.py
+++ b/arm/angles.py
@@ -1,0 +1,15 @@
+"""Utilities for servo angle conversions."""
+
+def angle_to_ticks(angle: float, min_us: int = 500, max_us: int = 2500, freq: int = 50) -> int:
+    """Convert a servo angle in degrees to PCA9685 tick counts.
+
+    :param angle: Angle in degrees (0-180)
+    :param min_us: Pulse width for 0 degrees in microseconds
+    :param max_us: Pulse width for 180 degrees in microseconds
+    :param freq: PWM frequency in Hz
+    :return: Tick count (0-4095)
+    """
+    pulse_len = 1000000 / freq
+    pulse = min_us + (max_us - min_us) * angle / 180
+    ticks = int(pulse * 4096 / pulse_len)
+    return ticks

--- a/arm/joystick.py
+++ b/arm/joystick.py
@@ -1,0 +1,24 @@
+"""Joystick input handling for Raspberry Pi Pico."""
+
+from machine import ADC, Pin
+
+class Joystick:
+    """Read a three-axis joystick with a push button."""
+
+    def __init__(self, x_pin=26, y_pin=27, z_pin=28, button_pin=16):
+        self.x = ADC(x_pin)
+        self.y = ADC(y_pin)
+        self.z = ADC(z_pin)
+        self.button = Pin(button_pin, Pin.IN, Pin.PULL_UP)
+
+    def read(self):
+        """Return tuple of (x, y, z, button) values.
+
+        Axes are 16-bit values from 0 to 65535. Button returns ``True`` when
+        pressed.
+        """
+        x_val = self.x.read_u16()
+        y_val = self.y.read_u16()
+        z_val = self.z.read_u16()
+        button_pressed = not self.button.value()
+        return x_val, y_val, z_val, button_pressed

--- a/arm/pca9685.py
+++ b/arm/pca9685.py
@@ -1,0 +1,31 @@
+"""Minimal PCA9685 driver for MicroPython."""
+
+from machine import I2C
+import utime
+
+_MODE1 = 0x00
+_PRESCALE = 0xFE
+_LED0_ON_L = 0x06
+
+class PCA9685:
+    """Driver for the PCA9685 16-channel PWM controller."""
+
+    def __init__(self, i2c: I2C, address: int = 0x40):
+        self.i2c = i2c
+        self.address = address
+
+    def _write(self, reg: int, value: int):
+        self.i2c.writeto_mem(self.address, reg, bytes([value & 0xFF]))
+
+    def set_freq(self, freq: int):
+        """Set PWM frequency in Hz."""
+        prescale = int(25000000 / (4096 * freq) - 1)
+        self._write(_MODE1, 0x10)  # sleep
+        self._write(_PRESCALE, prescale)
+        self._write(_MODE1, 0x80)  # restart
+        utime.sleep_ms(5)
+
+    def set_pwm(self, channel: int, on: int, off: int):
+        """Set on/off tick counts for a channel."""
+        data = bytearray([on & 0xFF, on >> 8, off & 0xFF, off >> 8])
+        self.i2c.writeto_mem(self.address, _LED0_ON_L + 4 * channel, data)

--- a/arm/robot_arm.py
+++ b/arm/robot_arm.py
@@ -1,0 +1,30 @@
+"""Robotic arm coordination logic."""
+
+import utime
+
+class RobotArm:
+    """Tie joystick input to servo outputs."""
+
+    def __init__(self, servo_controller, joystick):
+        self.servo = servo_controller
+        self.joystick = joystick
+        self.grip_open = False
+        self._last_button = False
+
+    def update(self):
+        x, y, z, button = self.joystick.read()
+        self.servo.set_angle(0, x * 180 / 65535)
+        self.servo.set_angle(1, y * 180 / 65535)
+        self.servo.set_angle(2, z * 180 / 65535)
+
+        if button and not self._last_button:
+            self.grip_open = not self.grip_open
+            angle = 90 if self.grip_open else 0
+            self.servo.set_angle(3, angle)
+        self._last_button = button
+
+    def loop(self, delay_ms: int = 50):
+        """Continuously update the arm based on joystick input."""
+        while True:
+            self.update()
+            utime.sleep_ms(delay_ms)

--- a/arm/servo_controller.py
+++ b/arm/servo_controller.py
@@ -1,0 +1,20 @@
+"""High level servo control using the PCA9685."""
+
+from .pca9685 import PCA9685
+from .angles import angle_to_ticks
+
+class ServoController:
+    """Control servos connected to a PCA9685."""
+
+    def __init__(self, i2c, address: int = 0x40, freq: int = 50,
+                 min_us: int = 500, max_us: int = 2500):
+        self.pca = PCA9685(i2c, address)
+        self.pca.set_freq(freq)
+        self.min_us = min_us
+        self.max_us = max_us
+        self.freq = freq
+
+    def set_angle(self, channel: int, angle: float):
+        """Set the angle of a servo on a specific channel."""
+        ticks = angle_to_ticks(angle, self.min_us, self.max_us, self.freq)
+        self.pca.set_pwm(channel, 0, ticks)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+"""Entry point for controlling the robotic arm."""
+
+from machine import I2C, Pin
+
+from arm.joystick import Joystick
+from arm.servo_controller import ServoController
+from arm.robot_arm import RobotArm
+
+
+def main():
+    i2c = I2C(0, scl=Pin(1), sda=Pin(0), freq=400_000)
+    joystick = Joystick()
+    servo = ServoController(i2c)
+    arm = RobotArm(servo, joystick)
+    arm.loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_angles.py
+++ b/tests/test_angles.py
@@ -1,0 +1,13 @@
+from arm.angles import angle_to_ticks
+
+
+def test_angle_to_ticks_zero():
+    assert angle_to_ticks(0) == 102
+
+
+def test_angle_to_ticks_middle():
+    assert angle_to_ticks(90) == 307
+
+
+def test_angle_to_ticks_max():
+    assert angle_to_ticks(180) == 512


### PR DESCRIPTION
## Summary
- Implement joystick, PCA9685, and servo controller modules for Raspberry Pi Pico
- Add high-level robotic arm logic with main entry point
- Include unit tests for servo angle to tick conversion

## Testing
- `python -m py_compile $(find . -name "*.py")`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6436cdd88833084588f4614d4ec18